### PR TITLE
PactoRequestFactory support query strings

### DIFF
--- a/src/Factory/Pacto/PactoRequestFactory.php
+++ b/src/Factory/Pacto/PactoRequestFactory.php
@@ -12,11 +12,17 @@ class PactoRequestFactory implements PactoRequestFactoryInterface
     {
         $body = isset($requestArray['body']) ? $requestArray['body'] : '';
 
+	$uriString = $requestArray['path'];
+        if (isset($requestArray['query'])) {
+            $uriString .= '?' . $requestArray['query'];
+        }		
+
         $bodyStream = new Stream('php://memory', 'w');
         $bodyStream->write(json_encode($body));
 
-        $request = new Request(
-            $requestArray['path'],
+        // build the PSR-7 request 
+	$request = new Request(
+            $uriString,
             $requestArray['method'],
             $bodyStream,
             isset($requestArray['headers']) ? $requestArray['headers'] : []

--- a/src/Factory/Pacto/PactoRequestFactory.php
+++ b/src/Factory/Pacto/PactoRequestFactory.php
@@ -12,6 +12,11 @@ class PactoRequestFactory implements PactoRequestFactoryInterface
     {
         $body = isset($requestArray['body']) ? $requestArray['body'] : '';
 
+	$uriString = $requestArray['path'];
+        if (isset($requestArray['query'])) {
+            $uriString .= '?' . $requestArray['query'];
+        }		
+
         $bodyStream = new Stream('php://memory', 'w');
         $bodyStream->write(json_encode($body));
 


### PR DESCRIPTION
PactoRequestFactory should append query from request array into the uri string. (PSR-7 request doesn't have its own field for GET query; it's parsed from the URI string.)



